### PR TITLE
Lh455 refactor mt asset on upload

### DIFF
--- a/lib/MT/CMS/Asset.pm
+++ b/lib/MT/CMS/Asset.pm
@@ -457,7 +457,7 @@ sub complete_insert {
 
 sub complete_upload {
     my $app   = shift;
-    my %param = $app->query->param;
+    my %param = %{ $app->query->Vars };
     my $asset;
     require MT::Asset;
     $param{id} && ( $asset = MT::Asset->load( $param{id} ) )
@@ -759,7 +759,7 @@ sub asset_insert_text {
 
 sub _process_post_upload {
     my $app   = shift;
-    my %param = $app->param; #TODO: Fix this when $app->query->param is a fully working substitute
+    my %param = %{ $app->query->Vars };
     my $asset;
     require MT::Asset;
     $param{id} && ( $asset = MT::Asset->load( $param{id} ) )


### PR DESCRIPTION
t/62-asset.t passes (when run as prove5.8.9 -w t/62-asset.t on my MacBook Pro). It also works on my blog.
