### PR TITLE
RPTDaemonTTL Config Directive

### DIFF
--- a/lib/MT/TheSchwartz.pm
+++ b/lib/MT/TheSchwartz.pm
@@ -257,6 +257,7 @@ sub work_periodically {
     $delay ||= 5;
     my $last_task_run = 0;
     my $did_work      = 0;
+    my $start = time;
 
     # holds state of objects at start
     my %obj_start;
@@ -295,6 +296,10 @@ sub work_periodically {
             }
         }
 
+        if (MT->config('RPTDaemonTTL')) {
+            exit if ((time - $start) > (MT->config('RPTDaemonTTL')));  # in seconds
+        }
+        
         sleep $delay;
     } ## end while (1)
 } ## end sub work_periodically


### PR DESCRIPTION
Implemented new RPTDaemonTTL config directive. This commit does not change default behavior, but if user has specified a value, in seconds, for RPTDaemonTTL, then any run-periodic-tasks daemons will exit after this limit has been reached. 

Primary usage is to avoid memory leak issues, works great when used in conjunction with daemontools supervise to auto-restart the rpt daemons.
