### PR TITLE
Lh522 copyright changes

### DIFF
--- a/build/minifier.pl
+++ b/build/minifier.pl
@@ -8,11 +8,11 @@ my $year = ( localtime(time) )[5] + 1900;
 
 if ( ( $ENV{BUILD_PACKAGE} || 'MTOS' ) ne 'MTOS' ) {
     $copyright
-      = "Movable Type (r) (C) 2001-$year Six Apart, Ltd. All Rights Reserved";
+      = "Movable Type (r) (C) 2001-$year Six Apart, Ltd. All Rights Reserved\nCopyright (C) 2009-$year Open Melody Software Group. All Rights Reserved.";
 }
 else {
     $copyright
-      = "Movable Type (r) Open Source (C) 2001-$year Six Apart, Ltd.";
+      = "Movable Type (r) Open Source (C) 2001-$year Six Apart, Ltd.\nCopyright (C) 2009-$year Open Melody Software Group. All Rights Reserved.";
 }
 
 my %types = ( css => 'CSS::Minifier', js => 'JavaScript::Minifier', );

--- a/lib/MT.pm
+++ b/lib/MT.pm
@@ -4469,7 +4469,8 @@ Movable Type.
 
 =head1 AUTHOR & COPYRIGHT
 
-Except where otherwise noted, MT is Copyright 2001-2009 Six Apart.
+Portions Copyright Six Apart.
+Copyright © 2009-2010 Open Melody Software Group.
 All rights reserved.
 
 =cut

--- a/mt-static/js/common/AdEngine.js
+++ b/mt-static/js/common/AdEngine.js
@@ -3,6 +3,7 @@ AdEngine
 $Id: AdEngine.js 226 2007-09-18 18:20:57Z janine $
 
 Copyright (c) 2006, Six Apart, Ltd.
+Copyright © 2009-2010 Open Melody Software Group.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/mt-static/js/common/App.js
+++ b/mt-static/js/common/App.js
@@ -1,5 +1,6 @@
 /**
  * App Library - Copyright (c) 2006 Six Apart
+ * Copyright © 2009-2010 Open Melody Software Group.
  * All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without

--- a/mt-static/js/common/Autolayout.js
+++ b/mt-static/js/common/Autolayout.js
@@ -3,6 +3,7 @@ DOM Autolayout Interface
 $Id: Autolayout.js 206 2007-05-30 20:57:07Z ddavis $
 
 Copyright (c) 2005, Six Apart, Ltd.
+Copyright © 2009-2010 Open Melody Software Group.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/mt-static/js/common/Cache.js
+++ b/mt-static/js/common/Cache.js
@@ -3,6 +3,7 @@ LRU Cache Library
 $Id: Cache.js 159 2007-04-24 01:05:37Z ydnar $
 
 Copyright (c) 2005, Six Apart, Ltd.
+Copyright © 2009-2010 Open Melody Software Group.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/mt-static/js/common/Calendar.js
+++ b/mt-static/js/common/Calendar.js
@@ -3,6 +3,7 @@ Calendar Utility
 $Id: Calendar.js 259 2008-02-06 05:04:04Z ddavis $
 
 Copyright (c) 2006, Six Apart, Ltd.
+Copyright © 2009-2010 Open Melody Software Group.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/mt-static/js/common/Client.js
+++ b/mt-static/js/common/Client.js
@@ -3,6 +3,7 @@ Client Library
 $Id: Client.js 250 2007-12-07 21:52:56Z ydnar $
 
 Copyright (c) 2005, Six Apart, Ltd.
+Copyright © 2009-2010 Open Melody Software Group.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/mt-static/js/common/Component.js
+++ b/mt-static/js/common/Component.js
@@ -3,6 +3,7 @@ DOM Component Library - Copyright 2005 Six Apart
 $Id: Component.js 212 2007-06-11 17:08:49Z ddavis $
 
 Copyright (c) 2005, Six Apart, Ltd.
+Copyright © 2009-2010 Open Melody Software Group.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/mt-static/js/common/Cookie.js
+++ b/mt-static/js/common/Cookie.js
@@ -3,6 +3,7 @@ Cookie JavaScript Library
 $Id: Cookie.js 247 2007-11-26 18:57:32Z ydnar $
 
 Copyright (c) 2007, Six Apart, Ltd.
+Copyright © 2009-2010 Open Melody Software Group.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/mt-static/js/common/Core.js
+++ b/mt-static/js/common/Core.js
@@ -3,6 +3,7 @@ Core JavaScript Library
 $Id: Core.js 251 2007-12-11 02:27:38Z ydnar $
 
 Copyright (c) 2005, Six Apart, Ltd.
+Copyright © 2009-2010 Open Melody Software Group.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/mt-static/js/common/DOM.js
+++ b/mt-static/js/common/DOM.js
@@ -3,6 +3,7 @@ DOM Library
 $Id: DOM.js 257 2007-12-19 20:16:39Z ddavis $
 
 Copyright (c) 2005, Six Apart, Ltd.
+Copyright © 2009-2010 Open Melody Software Group.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/mt-static/js/common/Devel.js
+++ b/mt-static/js/common/Devel.js
@@ -3,6 +3,7 @@ Development Library - Copyright 2005 Six Apart
 $Id: Devel.js 242 2007-11-02 17:07:29Z ydnar $
 
 Copyright (c) 2007, Six Apart, Ltd.
+Copyright © 2009-2010 Open Melody Software Group.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/mt-static/js/common/Dialog.js
+++ b/mt-static/js/common/Dialog.js
@@ -3,6 +3,7 @@ Dialog Library
 $Id: Dialog.js 159 2007-04-24 01:05:37Z ydnar $
 
 Copyright (c) 2006, Six Apart, Ltd.
+Copyright © 2009-2010 Open Melody Software Group.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/mt-static/js/common/Editor.js
+++ b/mt-static/js/common/Editor.js
@@ -3,6 +3,7 @@ Editor Library
 $Id: Editor.js 201 2007-05-29 22:51:10Z ddavis $
 
 Copyright (c) 2005, Six Apart, Ltd.
+Copyright © 2009-2010 Open Melody Software Group.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/mt-static/js/common/JSON.js
+++ b/mt-static/js/common/JSON.js
@@ -3,6 +3,7 @@ JavasSript Object Notation (JSON) - Copyright 2005 Six Apart
 $Id: JSON.js 264 2008-06-11 22:46:16Z ddavis $
 
 Copyright (c) 2005-2006, Six Apart, Ltd.
+Copyright © 2009-2010 Open Melody Software Group.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/mt-static/js/common/List.js
+++ b/mt-static/js/common/List.js
@@ -3,6 +3,7 @@ List Controller Component
 $Id: List.js 209 2007-06-01 19:21:10Z ddavis $
 
 Copyright (c) 2005, Six Apart, Ltd.
+Copyright © 2009-2010 Open Melody Software Group.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/mt-static/js/common/Observable.js
+++ b/mt-static/js/common/Observable.js
@@ -3,6 +3,7 @@ Observable Library
 $Id: Observable.js 159 2007-04-24 01:05:37Z ydnar $
 
 Copyright (c) 2006, Six Apart, Ltd.
+Copyright © 2009-2010 Open Melody Software Group.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/mt-static/js/common/Pager.js
+++ b/mt-static/js/common/Pager.js
@@ -3,6 +3,7 @@ Pagination Component
 $Id: Pager.js 159 2007-04-24 01:05:37Z ydnar $
 
 Copyright (c) 2006, Six Apart, Ltd.
+Copyright © 2009-2010 Open Melody Software Group.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/mt-static/js/common/SelectionRange.js
+++ b/mt-static/js/common/SelectionRange.js
@@ -1,5 +1,6 @@
 /*
 SelectionRange Class - Copyright 2005 Six Apart
+Copyright © 2009-2010 Open Melody Software Group.
 $Id: SelectionRange.js 164 2007-04-25 20:41:19Z ydnar $
 */
 

--- a/mt-static/js/common/SpellChecker.js
+++ b/mt-static/js/common/SpellChecker.js
@@ -3,6 +3,7 @@ Spell Checking Library
 $Id: SpellChecker.js 159 2007-04-24 01:05:37Z ydnar $
 
 Copyright (c) 2006, Six Apart, Ltd.
+Copyright © 2009-2010 Open Melody Software Group.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/mt-static/js/common/Template.js
+++ b/mt-static/js/common/Template.js
@@ -3,6 +3,7 @@ Template - Copyright 2005 Six Apart
 $Id: Template.js 204 2007-05-30 19:50:59Z ddavis $
 
 Copyright (c) 2005, Six Apart, Ltd.
+Copyright © 2009-2010 Open Melody Software Group.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/mt-static/js/common/Timer.js
+++ b/mt-static/js/common/Timer.js
@@ -3,6 +3,7 @@ Timer Library
 $Id: Timer.js 159 2007-04-24 01:05:37Z ydnar $
 
 Copyright (c) 2005, Six Apart, Ltd.
+Copyright © 2009-2010 Open Melody Software Group.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/mt-static/js/common/WordWalker.js
+++ b/mt-static/js/common/WordWalker.js
@@ -3,6 +3,7 @@ DOM WordWalker Library
 $Id: WordWalker.js 159 2007-04-24 01:05:37Z ydnar $
 
 Copyright (c) 2006, Six Apart, Ltd.
+Copyright © 2009-2010 Open Melody Software Group.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/t/44-spider.t
+++ b/t/44-spider.t
@@ -53,7 +53,7 @@ my $skip_pattern    = qr{logout|export|magic_token};
 my $must_match      = qr{(/cgi-bin/|^\?).*mt\.cgi};
 my $warning_pattern = qr{Uninitialized};
 my $good_pattern
-  = qr{Copyright .* 2001-\d+ Six Apart\. All Rights Reserved\.};
+  = qr{Copyright .* 2009-\d+ Open Melody Software Group\. All Rights Reserved\. };
 my $bad_pattern
   = qr{<input\s+type="submit"\s+value="Log In" />|time\s+to\s+upgrade!}i;
 

--- a/t/lib/MT/Test.pm
+++ b/t/lib/MT/Test.pm
@@ -1,5 +1,6 @@
 #############################################################################
 # Copyright © 2008-2010 Six Apart Ltd.
+# Copyright © 2009-2010 Open Melody Software Group.
 # $Id$
 
 package MT::Test;

--- a/tmpl/cms/include/copyright.tmpl
+++ b/tmpl/cms/include/copyright.tmpl
@@ -1,3 +1,3 @@
 <div id="copyright">
-    <MT_TRANS phrase="Copyright &copy; 2001-[_1] Six Apart. All Rights Reserved." params="<mt:date format="%Y">">
+    <MT_TRANS phrase="Copyright &copy; 2001-[_1] Six Apart; Copyright © 2009-2010 Open Melody Software Group. All Rights Reserved." params="<mt:date format="%Y">">
 </div>


### PR DESCRIPTION
That should clean it up. I changed the minifier script in build/. That seemed to be the scrip which automatically inserted the copyright notices in most files.
