### PR TITLE
Lh667 uninitialized value wizard mail

### DIFF
--- a/lib/MT/App/Wizard.pm
+++ b/lib/MT/App/Wizard.pm
@@ -861,12 +861,12 @@ sub optional {
       { id => 'sendmail', name => $app->translate('Sendmail') };
 
     foreach (@$transfer) {
-        if ( $_->{id} eq $param{mail_transfer} ) {
+        if ( $param{mail_transfer} && $_->{id} eq $param{mail_transfer} ) {
             $_->{selected} = 1;
         }
     }
 
-    $param{ 'use_' . $param{mail_transfer} } = 1;
+    $param{ 'use_' . $param{mail_transfer} } = 1 if $param{mail_transfer};
     $param{mail_loop}                        = $transfer;
     $param{config}                           = $app->serialize_config(%param);
 


### PR DESCRIPTION
Two one-line changes to lib/MT/App/Wizard.pm to suppress uninitialized warning messages displayed on wizard.cgi Mail Configuration page.  (Described in Lighthouse ticket #667)
