### PR TITLE
Lh604 blank activity log messages

### DIFF
--- a/lib/MT/App.pm
+++ b/lib/MT/App.pm
@@ -3664,7 +3664,7 @@ sub log {
     # we will turn into a hash reference filling in the
     # defaults for undefined values
     else {
-        $msg = { message => $msg, %defaults };
+        $msg = { %defaults, message => $msg };
     }
 
     # Now, send it on up to the SUPER class


### PR DESCRIPTION
Fix for mysterious blank activity log messages being recorded.
