### PR TITLE
Lh 738 drop json plugin

### DIFF
--- a/addons/ConfigAssistant.pack/config.yaml
+++ b/addons/ConfigAssistant.pack/config.yaml
@@ -4,8 +4,8 @@ key: ConfigAssistant
 author_link: http://openmelody.org/
 author_name: "Byrne Reese, Open Melody Software Group"
 description: This plugin provides a simple YAML based framework for creating plugin and theme configuration options.
-version: 2.1.18
-static_version: 8
+version: 2.1.21
+static_version: 9
 schema_version: 3
 
 applications:

--- a/addons/ConfigAssistant.pack/config.yaml
+++ b/addons/ConfigAssistant.pack/config.yaml
@@ -83,7 +83,7 @@ object_types:
 
 blog_preferences:
   __default__:
-    label: 'Movable Type Factory Default'
-    description: 'This is the default factory settings for Movable Type.'
+    label: 'Factory Default'
+    description: 'These are the default factory settings.'
     order: 1
     preferences: default_prefs.yaml

--- a/addons/ConfigAssistant.pack/lib/ConfigAssistant/Plugin.pm
+++ b/addons/ConfigAssistant.pack/lib/ConfigAssistant/Plugin.pm
@@ -363,19 +363,19 @@ sub save_config {
                 if ( $result->{status} == ConfigAssistant::Util::ERROR() ) {
                     return $app->error(
                               "Error uploading file: " . $result->{message} );
-                }
-                if ( $result->{status} == ConfigAssistant::Util::NO_UPLOAD ) {
+                } elsif ( $result->{status} == ConfigAssistant::Util::NO_UPLOAD ) {
                     if ($param->{$var.'-clear'} && $data->{$var}) {
                         my $old = MT->model('asset')->load( $data->{$var} );
                         $old->remove if $old;
+                        $param->{$var} = undef;
                     }
-                    next;
+                } else {
+                    if ( $data->{$var} ) {
+                        my $old = MT->model('asset')->load( $data->{$var} );
+                        $old->remove if $old;
+                    }
+                    $param->{$var} = $result->{asset}->{id};
                 }
-                if ( $data->{$var} ) {
-                    my $old = MT->model('asset')->load( $data->{$var} );
-                    $old->remove if $old;
-                }
-                $param->{$var} = $result->{asset}->{id};
             }
             my $old = $data->{$var};
             my $new = $param->{$var};
@@ -462,11 +462,11 @@ sub type_file {
               . "\">view</a> | <a href=\"javascript:void(0)\" class=\"remove\">remove</a></p>";
         }
         else {
-            $html .= "<p>File not found.</p>";
+            $html .= "<p>Selected asset could not be found. <a href=\"javascript:void(0)\" class=\"remove\">reset</a></p>";
         }
     }
     $html .= "      <input type=\"file\" name=\"$field_id\" class=\"full-width\" />\n" .
-        "      <input type=\"hidden\" name=\"$field_id-clear\" value=\"0\" class=\"clear-file\" />\n";
+             "      <input type=\"hidden\" name=\"$field_id-clear\" value=\"0\" class=\"clear-file\" />\n";
 
     $html .= "<script type=\"text/javascript\">\n";
     $html .= "  \$('#field-".$field_id." a.remove').click( handle_remove_file );\n";

--- a/addons/ConfigAssistant.pack/lib/ConfigAssistant/Plugin.pm
+++ b/addons/ConfigAssistant.pack/lib/ConfigAssistant/Plugin.pm
@@ -504,7 +504,7 @@ sub type_link_group {
     my ( $ctx, $field_id, $field, $value ) = @_;
     my $static = $app->static_path;
     $value = '"[]"' if ( !$value || $value eq '' );
-    eval "\$value = $value";
+    eval "\$value = \"$value\"";
     if ($@) { $value = '"[]"'; }
     my $list;
     eval { $list = JSON::from_json($value) };
@@ -542,7 +542,7 @@ sub type_link_group {
       var l = \$(this).html();
       struct.push( { 'url': u, 'label': l } );
     });
-    var json = \$.toJSON(struct);
+    var json = struct.toJSON().escapeJS();
     \$('#'+'$field_id').val( json );
   });
   \$('#'+'$field_id-link-group ul li a.remove').click( handle_delete_click );
@@ -1067,7 +1067,7 @@ sub _hdlr_field_link_group {
     my $field = $ctx->stash('field') or return _no_field($ctx);
     my $value = _get_field_value($ctx);
     $value = '"[]"' if ( !$value || $value eq '' );
-    eval "\$value = $value";
+    eval "\$value = \"$value\"";
     if ($@) { $value = '[]'; }
     my $list = JSON::from_json($value);
 
@@ -1468,7 +1468,6 @@ END_TMPL
 </mt:unless>
   <script src="<mt:PluginStaticWebPath component="configassistant">js/options.js" type="text/javascript"></script>
   <script src="<mt:PluginStaticWebPath component="configassistant">colorpicker/js/colorpicker.js" type="text/javascript"></script>
-  <script src="<mt:PluginStaticWebPath component="configassistant">js/jquery.json-2.2.min.js" type="text/javascript"></script>
 </mt:setvarblock>
 END_TMPL
 

--- a/addons/ConfigAssistant.pack/lib/ConfigAssistant/Util.pm
+++ b/addons/ConfigAssistant.pack/lib/ConfigAssistant/Util.pm
@@ -147,8 +147,8 @@ sub process_file_upload {
         $root_path = File::Spec->catdir( $app->static_file_path, 'support' );
         $base_url  = $app->static_path . '/support';
         $fmgr      = MT::FileMgr->new('Local');
-        $blog_id = 0;    # the resulting asset will be added to this context
-        $format = File::Spec->catfile( '%s', 'support' );
+        $blog_id   = $app->blog ? $app->blog->id : 0;  # the resulting asset will be added to this context
+        $format    = File::Spec->catfile( '%s', 'support' );
 
     }
     else {

--- a/addons/ConfigAssistant.pack/lib/ConfigAssistant/Util.pm
+++ b/addons/ConfigAssistant.pack/lib/ConfigAssistant/Util.pm
@@ -123,9 +123,8 @@ sub process_file_upload {
         $root_path = $app->blog->site_path;
         $base_url  = $app->blog->site_url;
         $fmgr      = $app->blog->file_mgr;
-        $blog_id   = $app->blog
-          ->id;    # the resulting asset will be added to this context
-        $format = '%r';
+        $blog_id   = $app->blog->id;    # the resulting asset will be added to this context
+        $format    = '%r';
 
     }
     elsif ( lc($scope) eq 'archive' ) {
@@ -139,8 +138,7 @@ sub process_file_upload {
         $root_path = $app->blog->archive_path;
         $base_url  = $app->blog->archive_url;
         $fmgr      = $app->blog->file_mgr;
-        $blog_id   = $app->blog
-          ->id;    # the resulting asset will be added to this context
+        $blog_id   = $app->blog->id;    # the resulting asset will be added to this context
         $format = '%a';
 
     }

--- a/addons/ConfigAssistant.pack/static/js/options.js
+++ b/addons/ConfigAssistant.pack/static/js/options.js
@@ -1,12 +1,14 @@
 // Utility Functions
 function handle_edit_click() {
-    var link = $(this).parent().find('a.link');
+    var p = $(this).parent();
+    var link = p.find('a.link');
     if (link.length > 0) {
-        $(this).parent().replaceWith( render_link_form( link.html(), link.attr('href') ) );
+        p.replaceWith( render_link_form( link.html(), link.attr('href') ) );
     } else {
-        $(this).parent().before( render_link_form( '','' ) );
-        $(this).parent().hide();
+        p.before( render_link_form( '','' ) );
+        p.hide();
     }
+    p.parent().find('input.label').focus();
     return false;
 };
 function render_link(label,url) {
@@ -42,7 +44,7 @@ function render_link_form(label,url) {
                 e.find('button').trigger('click');
                 return false;
             }
-        });
+    });
     }).blur( function() {
         $(this).unbind('keypress');
     });

--- a/addons/ConfigAssistant.pack/tmpl/theme_options.mtml
+++ b/addons/ConfigAssistant.pack/tmpl/theme_options.mtml
@@ -43,13 +43,12 @@
   <link rel="stylesheet" href="<$mt:PluginStaticWebPath component="configassistant"$>css/app.css" type="text/css" />
   <link rel="stylesheet" href="<$mt:PluginStaticWebPath component="configassistant"$>colorpicker/css/colorpicker.css" type="text/css" />
 <mt:unless tag="ProductName" eq="Melody">
-  <script src="<$mt:StaticWebPath$>jquery/jquery.js" type="text/javascript"></script>
+  <script src="<mt:StaticWebPath>jquery/jquery.js" type="text/javascript"></script>
 </mt:unless>
   <script src="<$mt:PluginStaticWebPath component="configassistant"$>js/jquery.history.js" type="text/javascript"></script>
   <script src="<$mt:PluginStaticWebPath component="configassistant"$>js/app.js" type="text/javascript"></script>
   <script src="<$mt:PluginStaticWebPath component="configassistant"$>js/options.js" type="text/javascript"></script>
   <script src="<$mt:PluginStaticWebPath component="configassistant"$>colorpicker/js/colorpicker.js" type="text/javascript"></script>
-  <script src="<$mt:PluginStaticWebPath component="configassistant"$>js/jquery.json-2.2.min.js" type="text/javascript"></script>
 </mt:setvarblock>
 
 <mt:var name="screen_id" value="theme_options">

--- a/lib/MT/L10N/es.pm
+++ b/lib/MT/L10N/es.pm
@@ -6048,7 +6048,7 @@ que la dirección provista es correcta y le pertenece.',
     'Chooser'                   => 'Chooser',
 
 ## addons/ConfigAssistant.pack/config.yaml
-    'Movable Type Factory Default\'' =>
+    'Factory Default\'' =>
       'Opciones predeterminadas de fábrica\'',
 
 ## addons/ThemeExport.plugin/tmpl/dialog_export.tmpl


### PR DESCRIPTION
There are a number of issues associated with this pull request resulting from having to manage two separate copies of config assistant. We really need to investigate using git submodules more. But I digress. 

Here are the issues associated with this pull request:

1) Eliminated the conflict with the jquery.json.js plugin.
2) A client of Endevver's noticed that when an asset is uploaded and associated with a theme option and then later deleted, that there is no way for an admin to then unassociated that [missing] asset with the theme option. I fixed that. This issue was in the mt-plugin-configassistant repo and was not in melody's. This is issue #750.
3) There are some small spacing changes made during development. These are innocuous. 
4) Finally, ticket #751 was resolved in which ALL assets uploaded via Config Assistant were associated with the system level. Doh!
