### PR TITLE
Remove asset association methods

### DIFF
--- a/lib/MT/CMS/Entry.pm
+++ b/lib/MT/CMS/Entry.pm
@@ -1161,10 +1161,10 @@ sub save {
         }
         $seen->{$asset_id} = 1;
     }
-    foreach my $asset_id ( keys %{$obj_assets} ) {
-        my $asset = MT->model('asset')->load($asset_id);
-        unless ( $seen->{$asset_id} ) {
-            $asset->unassociate($obj);
+    foreach my $asset_id (keys %{$obj_assets}) {
+        unless ($seen->{$asset_id}) {
+            my $obj_asset = MT::ObjectAsset->load({ asset_id => $asset_id, object_ds => 'entry', object_id => $obj->id });
+            $obj_asset->remove;
         }
     }
 

--- a/lib/MT/CMS/Entry.pm
+++ b/lib/MT/CMS/Entry.pm
@@ -1150,9 +1150,14 @@ sub save {
     }
     my $seen = ();
     foreach my $asset_id (@asset_ids) {
-        my $asset = MT->model('asset')->load($asset_id);
-        unless ( $asset->is_associated($obj) ) {
-            $asset->associate( $obj, 0 );
+        my $obj_asset = MT::ObjectAsset->load({ asset_id => $asset_id, object_ds => 'entry', object_id => $obj->id });
+        unless ($obj_asset) {
+            my $obj_asset = new MT::ObjectAsset;
+            $obj_asset->blog_id($blog_id);
+            $obj_asset->asset_id($asset_id);
+            $obj_asset->object_ds('entry');
+            $obj_asset->object_id($obj->id);
+            $obj_asset->save;
         }
         $seen->{$asset_id} = 1;
     }


### PR DESCRIPTION
The MT/Asset->association methods do not currently support pages. The two commits of this branch roll back the addition of these methods on the MT/CMS/Entry module. See https://github.com/openmelody/melody/commit/ee1a0518397a3bbbcd1a0e6f9f543b60821b080c
